### PR TITLE
Bb dev - email formatting fixes when sending to data author

### DIFF
--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -180,6 +180,11 @@ def submit():
         for plugin in PluginImplementations(IContact):
             plugin.mail_alter(mail_dict, data_dict)
 
+        log.info('Attempting to email {}'.format( mail_dict["recipient_email"] ))
+        log.info('Attempting to cc {}'.format( mail_dict["cc"] ))
+
+        breakpoint()
+
         try:
             mailer.mail_recipient(**mail_dict)
         except (mailer.MailerException, socket.error):

--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -180,10 +180,11 @@ def submit():
         for plugin in PluginImplementations(IContact):
             plugin.mail_alter(mail_dict, data_dict)
 
+        log.info(data_dict)
+        log.info(mail_dict)
         log.info('Attempting to email {}'.format( mail_dict["recipient_email"] ))
-        log.info('Attempting to cc {}'.format( mail_dict["cc"] ))
-
-        breakpoint()
+        if "cc" in mail_dict:
+            log.info('Attempting to cc {}'.format( mail_dict["cc"] ))
 
         try:
             mailer.mail_recipient(**mail_dict)


### PR DESCRIPTION
Fixed email address formatting so that the name part isn't set to Texas Water Data Hub when the email is being sent to the Data Author.

Instead of "Texas Water Data Hub <author@example.com>' the email is sent to plain old author@example.com, and of course still cc'd to "Texas Water Data Hub <DataHub@twdb.texas.gov"